### PR TITLE
Test

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
-ignore = E203, E266
+inline-quotes = "
+ignore = E203, E266, W503, ANN002, ANN003, ANN101, ANN102, ANN401, N807, N818
 max-line-length = 79
 max-complexity = 18
-select = B,C,E,F,W,T4,B9
+select = B,C,E,F,W,T4,B9,ANN,Q0,N8,VNE
 exclude = venv, tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Set Up Python 3.8
+      - name: Set Up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install pytest and flake8
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Run flake8
         run: flake8 app/
       - name: Run tests
+        timeout-minutes: 5
         run: pytest tests/
-

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 venv/
 .pytest_cache/
+**__pycache__/

--- a/README.md
+++ b/README.md
@@ -337,3 +337,5 @@ errors = [
     },
 ]
 ```
+
+### Note: Check your code using this [checklist](checklist.md) before pushing your solution.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Linter formatter
 
-- Read [the guideline](https://github.com/mate-academy/py-task-guideline/blob/main/README.md) before start
+Read [the guideline](https://github.com/mate-academy/py-task-guideline/blob/main/README.md) before starting.
 
 The `flake8` linter gives the following error report when checking a directory with source code files:
+
 ```python
 errors = {
     "./test_source_code_2.py": [],
@@ -99,18 +100,150 @@ errors = {
     ],
 }
 ```
+
 Here `errors` is a dictionary, where the keys are the path to the file, 
 and the value of this key is a list of errors, where each is a dictionary.
 
 But we store the execution results in a slightly different format.
 Write 3 functions to convert the report into the format we need:
-1. `format_linter_error` - formats a single error;
-2. `format_single_linter_file` - formats all errors for a particular file;
-3. `format_linter_report` - formats all errors for all report files.
+1. `format_linter_error` - formats a single error:
+
+```python
+error = {
+    "code": "E501",
+    "filename": "./source_code_2.py",
+    "line_number": 18,
+    "column_number": 80,
+    "text": "line too long (99 > 79 characters)",
+    "physical_line": '    return f"I like to filter, rounding, doubling, '
+    "store and decorate numbers: {', '.join(items)}!\"",
+}
+
+print(format_linter_error(error=error))
+# The output will be:
+{
+    "line": 18, 
+    "column": 80, 
+    "message": "line too long (99 > 79 characters)", 
+    "name": "E501", 
+    "source": "flake8"
+}
+```
+
+2. `format_single_linter_file` - formats all errors for a particular file and adds the `path` key — path to the file,
+and the `status` key — "failed" if there are errors, "passed" if there are no errors:
+
+```python
+errors = [
+    {
+        "code": "E501",
+        "filename": "./source_code_2.py",
+        "line_number": 18,
+        "column_number": 80,
+         "text": "line too long (99 > 79 characters)",
+        "physical_line": '    return f"I like to filter, rounding, doubling, ' 
+        "store and decorate numbers: {', '.join(items)}!\"",
+    },
+    {
+        "code": "W292",
+        "filename": "./source_code_2.py",
+        "line_number": 18,
+        "column_number": 100,
+        "text": "no newline at end of file",
+        "physical_line": '    return f"I like to filter, rounding, doubling, '
+        "store and decorate numbers: {', '.join(items)}!\"",
+    },
+]
+
+print(format_single_linter_file(file_path="./source_code_2.py", errors=errors))
+# The output will be:
+{
+    "errors": 
+        [
+            {
+                "line": 18, 
+                "column": 80, 
+                "message": "line too long (99 > 79 characters)", 
+                "name": "E501", 
+                "source": "flake8"
+            }, 
+            {
+                "line": 18, 
+                "column": 100, 
+                "message": "no newline at end of file", 
+                "name": "W292", 
+                "source": "flake8"
+            }
+        ], 
+    "path": "./source_code_2.py", 
+    "status": "failed"
+}
+```
+
+3. `format_linter_report` - formats all errors for all report files:
+
+```python
+report_file = {
+    "./test_source_code_2.py": [],
+    "./source_code_2.py":
+        [
+            {
+                "code": "E501",
+                "filename": "./source_code_2.py",
+                "line_number": 18,
+                "column_number": 80,
+                "text": "line too long (99 > 79 characters)",
+                "physical_line": '    return f"I like to filter, rounding, doubling, '
+                "store and decorate numbers: {', '.join(items)}!\"",
+            },
+            {
+                "code": "W292",
+                "filename": "./source_code_2.py",
+                "line_number": 18,
+                "column_number": 100,
+                "text": "no newline at end of file",
+                "physical_line": '    return f"I like to filter, rounding, doubling, '
+                "store and decorate numbers: {', '.join(items)}!\"",
+            },
+        ]
+}
+
+print(format_linter_report(linter_report=report_file))
+# The output will be:
+[
+    {
+        "errors": [], 
+        "path": "./test_source_code_2.py", 
+        "status": "passed"
+    }, 
+    {
+        "errors": 
+            [
+                {
+                    "line": 18, 
+                    "column": 80, 
+                    "message": "line too long (99 > 79 characters)", 
+                    "name": "E501", 
+                    "source": "flake8"
+                }, 
+                {
+                    "line": 18, 
+                    "column": 100, 
+                    "message": "no newline at end of file", 
+                    "name": "W292", 
+                    "source": "flake8"
+                }
+            ], 
+        "path": "./source_code_2.py", 
+        "status": "failed"
+    }
+]
+```
 
 All functions must contain only the `return` keyword.
 
 Required storage format:
+
 ```python
 errors = [
     {"errors": [], "path": "./test_source_code_2.py", "status": "passed"},

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 - Read [the guideline](https://github.com/mate-academy/py-task-guideline/blob/main/README.md) before start
 
-Линтер flake8 выдает такой отчет об ошибках при проверке каталога с файлами исходного 
-кода:
+The flake8 linter gives the following error report when checking a directory with source code files:
 ```python
 errors = {
     "./test_source_code_2.py": [],
@@ -100,18 +99,18 @@ errors = {
     ],
 }
 ```
-Здесь `errors` это словарь, в котором ключи - путь к файлу, а значение этого ключа -
-список ошибок, где каждая ошибка - словарь
+Here `errors` is a dictionary, where the keys are the path to the file, 
+and the value of this key is a list of errors, where each error is a dictionary.
 
-Но мы храним результаты выполнения немного в другом формате.
-Напиши 3 функции, чтобы преобразовать отчет в нужном нам формате.
-1. `format_linter_error` - форматирует отдельно взятую ошибку
-2. `format_single_linter_file` - форматирует все ошибки для конкретного файла
-3. `format_linter_report` - форматирует все ошибки для всех файлов в отчете
+But we store the execution results in a slightly different format.
+Write 3 functions to convert the report in the format we need.
+1. `format_linter_error` - formats a single error.
+2. `format_single_linter_file` - formats all errors for a particular file.
+3. `format_linter_report` - formats all errors for all files in the report.
 
-Все функции должны вмещать в себе только конструкцию `return`
+All functions must contain only the `return` construct.
 
-Требуемый формат хранения:
+Required storage format:
 ```python
 errors = [
     {"errors": [], "path": "./test_source_code_2.py", "status": "passed"},

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - Read [the guideline](https://github.com/mate-academy/py-task-guideline/blob/main/README.md) before start
 
-The flake8 linter gives the following error report when checking a directory with source code files:
+The `flake8` linter gives the following error report when checking a directory with source code files:
 ```python
 errors = {
     "./test_source_code_2.py": [],
@@ -100,15 +100,15 @@ errors = {
 }
 ```
 Here `errors` is a dictionary, where the keys are the path to the file, 
-and the value of this key is a list of errors, where each error is a dictionary.
+and the value of this key is a list of errors, where each is a dictionary.
 
 But we store the execution results in a slightly different format.
-Write 3 functions to convert the report in the format we need.
-1. `format_linter_error` - formats a single error.
-2. `format_single_linter_file` - formats all errors for a particular file.
-3. `format_linter_report` - formats all errors for all files in the report.
+Write 3 functions to convert the report into the format we need:
+1. `format_linter_error` - formats a single error;
+2. `format_single_linter_file` - formats all errors for a particular file;
+3. `format_linter_report` - formats all errors for all report files.
 
-All functions must contain only the `return` construct.
+All functions must contain only the `return` keyword.
 
 Required storage format:
 ```python

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,13 @@
 def format_linter_error(error: dict) -> dict:
-    # white your code here
+    # write your code here
     pass
 
 
 def format_single_linter_file(file_path: str, errors: list) -> dict:
-    # white your code here
+    # write your code here
     pass
 
 
 def format_linter_report(linter_report: dict) -> list:
-    # white your code here
+    # write your code here
     pass

--- a/checklist.md
+++ b/checklist.md
@@ -1,0 +1,53 @@
+# Сheck Your Code Against the Following Points
+
+## Don't Repeat Yourself
+
+Make sure you don't have duplicated lines or whole blocks of code. Use your `format_linter_error` function to avoid this.
+
+Also, use the `format_single_linter_file` function to format a single file.
+
+## Code Style
+
+Use descriptive and correct variable names.
+
+Good example:
+
+```python
+my_dict = {"one": "a", "two": "b"}
+[(number + " " + letter) for (number, letter) in my_dict.items()]
+```
+
+Bad example:
+
+```python
+my_dict = {"one": "a", "two": "b"}
+[(k + "  " + v) for (k, v) in my_dict.items()]
+```
+
+While creating a dictionary — write key-value pairs in a single row. The curly braces must be located in one of two options: open and start with the text or have a line break between the text. 
+
+Good example:
+
+```python
+my_dict = {
+"greeting": "Good morning, have a nice day!", 
+	"answer": "Good morning, thanks!"
+}
+
+```
+
+Also a good example:
+
+```python
+my_dict = {"greeting": "Good morning, have a nice day!", 
+	      "answer": "Good morning, thanks!"}
+```
+
+Bad example:
+
+```python
+my_dict = {"greeting": "Good morning, have a nice day!", 
+	      "answer": "Good morning, thanks!"
+}
+```
+

--- a/checklist.md
+++ b/checklist.md
@@ -30,7 +30,7 @@ Good example:
 
 ```python
 my_dict = {
-"greeting": "Good morning, have a nice day!", 
+	"greeting": "Good morning, have a nice day!", 
 	"answer": "Good morning, thanks!"
 }
 
@@ -40,14 +40,14 @@ Also a good example:
 
 ```python
 my_dict = {"greeting": "Good morning, have a nice day!", 
-	      "answer": "Good morning, thanks!"}
+	   "answer": "Good morning, thanks!"}
 ```
 
 Bad example:
 
 ```python
 my_dict = {"greeting": "Good morning, have a nice day!", 
-	      "answer": "Good morning, thanks!"
+	   "answer": "Good morning, thanks!"
 }
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
-pytest==6.2.5
-flake8==4.0.1
+flake8==5.0.4
+flake8-annotations==2.9.1
+flake8-quotes==3.3.1
+flake8-variables-names==0.0.5
+pep8-naming==0.13.2
+pytest==7.1.3

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 import ast
 import inspect
 
@@ -343,3 +344,24 @@ def test_format_linter_report(errors_linter, errors_mate):
         f"Function 'format_linter_report' should return {errors_mate} "
         f"when 'errors' equals to {errors_linter}"
     )
+
+
+def test_removed_comment():
+    import app
+    with open(app.main.__file__, "r") as f:
+        file_content = f.read()
+        comment = re.compile("# write your code here")
+        assert not comment.search(
+            file_content
+        ), "You have to remove the unnecessary comment '# write your code here'"
+
+
+def test_double_quotes_instead_of_single():
+    import app
+    with open(app.main.__file__, "r") as f:
+        file_content = f.read()
+        comment = re.compile("\'")
+        assert not comment.search(
+            file_content
+        ), "You have to use a double quotes \"\" instead of single \'\'"
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,34 +14,34 @@ from app.main import (
     "error_linter,error_mate",
     [
         (
-                {
-                    "code": "E501",
-                    "filename": "./source_code_2.py",
-                    "line_number": 18,
-                    "column_number": 80,
-                    "text": "line too long (99 > 79 characters)",
-                    "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                     "store and decorate numbers: {', '.join(items)}!\"",
-                },
-                {
-                    "line": 18,
-                    "column": 80,
-                    "message": "line too long (99 > 79 characters)",
-                    "name": "E501",
-                    "source": "flake8",
-                },
+            {
+                "code": "E501",
+                "filename": "./source_code_2.py",
+                "line_number": 18,
+                "column_number": 80,
+                "text": "line too long (99 > 79 characters)",
+                "physical_line": '    return f"I like to filter, rounding, doubling, '
+                                 "store and decorate numbers: {', '.join(items)}!\"",
+            },
+            {
+                "line": 18,
+                "column": 80,
+                "message": "line too long (99 > 79 characters)",
+                "name": "E501",
+                "source": "flake8",
+            },
         ),
         (
-                {
-                    "code": "E702",
-                    "filename": "./source_code_1.py",
-                    "line_number": 3,
-                    "column_number": 74,
-                    "text": "multiple statements on one line (semicolon)",
-                    "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                                     "value in items.items()]; return func(new_items)\n",
-                },
-                {
+            {
+                "code": "E702",
+                "filename": "./source_code_1.py",
+                "line_number": 3,
+                "column_number": 74,
+                "text": "multiple statements on one line (semicolon)",
+                "physical_line": '        new_items = [f"{key} -> {value}" for key, '
+                                 "value in items.items()]; return func(new_items)\n",
+            },
+            {
                     "line": 3,
                     "column": 74,
                     "message": "multiple statements on one line (semicolon)",
@@ -50,15 +50,15 @@ from app.main import (
                 },
         ),
         (
-                {
-                    "code": "E302",
-                    "filename": "./source_code_1.py",
-                    "line_number": 15,
-                    "column_number": 1,
-                    "text": "expected 2 blank lines, found 1",
-                    "physical_line": "def number_filter(func):\n",
-                },
-                {
+            {
+                "code": "E302",
+                "filename": "./source_code_1.py",
+                "line_number": 15,
+                "column_number": 1,
+                "text": "expected 2 blank lines, found 1",
+                "physical_line": "def number_filter(func):\n",
+            },
+            {
                     "line": 15,
                     "column": 1,
                     "message": "expected 2 blank lines, found 1",
@@ -94,7 +94,7 @@ def test_format_functions_one_line(func):
     "file_path,errors,result",
     [
         (
-                "./source_code_2.py",
+            "./source_code_2.py",
                 [
                     {
                         "code": "E501",
@@ -150,102 +150,102 @@ def test_format_single_linter_file(file_path, errors, result):
     "errors_linter,errors_mate",
     [
         (
-                {
-                    "./test_source_code_2.py": [],
-                    "./source_code_2.py": [
-                        {
-                            "code": "E501",
-                            "filename": "./source_code_2.py",
-                            "line_number": 18,
-                            "column_number": 80,
-                            "text": "line too long (99 > 79 characters)",
-                            "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                             "store and decorate numbers: {', '.join(items)}!\"",
-                        },
-                        {
-                            "code": "W292",
-                            "filename": "./source_code_2.py",
-                            "line_number": 18,
-                            "column_number": 100,
-                            "text": "no newline at end of file",
-                            "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                             "store and decorate numbers: {', '.join(items)}!\"",
-                        },
-                    ],
-                    "./source_code_1.py": [
-                        {
-                            "code": "E702",
-                            "filename": "./source_code_1.py",
-                            "line_number": 3,
-                            "column_number": 74,
-                            "text": "multiple statements on one line (semicolon)",
-                            "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                                             "value in items.items()]; return func(new_items)\n",
-                        },
-                        {
-                            "code": "E501",
-                            "filename": "./source_code_1.py",
-                            "line_number": 3,
-                            "column_number": 80,
-                            "text": "line too long (97 > 79 characters)",
-                            "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                                             "value in items.items()]; return func(new_items)\n",
-                        },
-                        {
-                            "code": "E302",
-                            "filename": "./source_code_1.py",
-                            "line_number": 15,
-                            "column_number": 1,
-                            "text": "expected 2 blank lines, found 1",
-                            "physical_line": "def number_filter(func):\n",
-                        },
-                        {
-                            "code": "E303",
-                            "filename": "./source_code_1.py",
-                            "line_number": 27,
-                            "column_number": 1,
-                            "text": "too many blank lines (6)",
-                            "physical_line": "@number_filter\n",
-                        },
-                        {
-                            "code": "E501",
-                            "filename": "./source_code_1.py",
-                            "line_number": 31,
-                            "column_number": 80,
-                            "text": "line too long (99 > 79 characters)",
-                            "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                             "store and decorate numbers: {', '.join(items)}!\"\n",
-                        },
-                    ],
-                    "./test_source_code_1.py": [
-                        {
-                            "code": "E302",
-                            "filename": "./test_source_code_1.py",
-                            "line_number": 4,
-                            "column_number": 1,
-                            "text": "expected 2 blank lines, found 1",
-                            "physical_line": "@pytest.mark.parametrize(\n",
-                        },
-                        {
-                            "code": "E501",
-                            "filename": "./test_source_code_1.py",
-                            "line_number": 32,
-                            "column_number": 80,
-                            "text": "line too long (84 > 79 characters)",
-                            "physical_line": '            "decorate numbers: 1 -> 2, 2 -> 4, 6 -> 12, -111 -> -222, -50 -> '
-                                             '-100!",\n',
-                        },
-                        {
-                            "code": "W292",
-                            "filename": "./test_source_code_1.py",
-                            "line_number": 112,
-                            "column_number": 6,
-                            "text": "no newline at end of file",
-                            "physical_line": "    )",
-                        },
-                    ],
-                },
-                [
+            {
+                "./test_source_code_2.py": [],
+                "./source_code_2.py": [
+                    {
+                        "code": "E501",
+                        "filename": "./source_code_2.py",
+                        "line_number": 18,
+                        "column_number": 80,
+                        "text": "line too long (99 > 79 characters)",
+                        "physical_line": '    return f"I like to filter, rounding, doubling, '
+                                         "store and decorate numbers: {', '.join(items)}!\"",
+                    },
+                    {
+                        "code": "W292",
+                        "filename": "./source_code_2.py",
+                        "line_number": 18,
+                        "column_number": 100,
+                        "text": "no newline at end of file",
+                        "physical_line": '    return f"I like to filter, rounding, doubling, '
+                                         "store and decorate numbers: {', '.join(items)}!\"",
+                    },
+                ],
+                "./source_code_1.py": [
+                    {
+                        "code": "E702",
+                        "filename": "./source_code_1.py",
+                        "line_number": 3,
+                        "column_number": 74,
+                        "text": "multiple statements on one line (semicolon)",
+                        "physical_line": '        new_items = [f"{key} -> {value}" for key, '
+                                         "value in items.items()]; return func(new_items)\n",
+                    },
+                    {
+                        "code": "E501",
+                        "filename": "./source_code_1.py",
+                        "line_number": 3,
+                        "column_number": 80,
+                        "text": "line too long (97 > 79 characters)",
+                        "physical_line": '        new_items = [f"{key} -> {value}" for key, '
+                                         "value in items.items()]; return func(new_items)\n",
+                    },
+                    {
+                        "code": "E302",
+                        "filename": "./source_code_1.py",
+                        "line_number": 15,
+                        "column_number": 1,
+                        "text": "expected 2 blank lines, found 1",
+                        "physical_line": "def number_filter(func):\n",
+                    },
+                    {
+                        "code": "E303",
+                        "filename": "./source_code_1.py",
+                        "line_number": 27,
+                        "column_number": 1,
+                        "text": "too many blank lines (6)",
+                        "physical_line": "@number_filter\n",
+                    },
+                    {
+                        "code": "E501",
+                        "filename": "./source_code_1.py",
+                        "line_number": 31,
+                        "column_number": 80,
+                        "text": "line too long (99 > 79 characters)",
+                        "physical_line": '    return f"I like to filter, rounding, doubling, '
+                                         "store and decorate numbers: {', '.join(items)}!\"\n",
+                    },
+                ],
+                "./test_source_code_1.py": [
+                    {
+                        "code": "E302",
+                        "filename": "./test_source_code_1.py",
+                        "line_number": 4,
+                        "column_number": 1,
+                        "text": "expected 2 blank lines, found 1",
+                        "physical_line": "@pytest.mark.parametrize(\n",
+                    },
+                    {
+                        "code": "E501",
+                        "filename": "./test_source_code_1.py",
+                        "line_number": 32,
+                        "column_number": 80,
+                        "text": "line too long (84 > 79 characters)",
+                        "physical_line": '            "decorate numbers: 1 -> 2, 2 -> 4, 6 -> 12, -111 -> -222, -50 -> '
+                                         '-100!",\n',
+                    },
+                    {
+                        "code": "W292",
+                        "filename": "./test_source_code_1.py",
+                        "line_number": 112,
+                        "column_number": 6,
+                        "text": "no newline at end of file",
+                        "physical_line": "    )",
+                    },
+                ],
+            },
+            [
                     {"errors": [], "path": "./test_source_code_2.py", "status": "passed"},
                     {
                         "errors": [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,7 +21,7 @@ from app.main import (
                 "column_number": 80,
                 "text": "line too long (99 > 79 characters)",
                 "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                 "store and decorate numbers: {', '.join(items)}!\"",
+                "store and decorate numbers: {', '.join(items)}!\"",
             },
             {
                 "line": 18,
@@ -39,15 +39,15 @@ from app.main import (
                 "column_number": 74,
                 "text": "multiple statements on one line (semicolon)",
                 "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                                 "value in items.items()]; return func(new_items)\n",
+                "value in items.items()]; return func(new_items)\n",
             },
             {
-                    "line": 3,
-                    "column": 74,
-                    "message": "multiple statements on one line (semicolon)",
-                    "name": "E702",
-                    "source": "flake8",
-                },
+                "line": 3,
+                "column": 74,
+                "message": "multiple statements on one line (semicolon)",
+                "name": "E702",
+                "source": "flake8",
+            },
         ),
         (
             {
@@ -59,12 +59,12 @@ from app.main import (
                 "physical_line": "def number_filter(func):\n",
             },
             {
-                    "line": 15,
-                    "column": 1,
-                    "message": "expected 2 blank lines, found 1",
-                    "name": "E302",
-                    "source": "flake8",
-                },
+                "line": 15,
+                "column": 1,
+                "message": "expected 2 blank lines, found 1",
+                "name": "E302",
+                "source": "flake8",
+            },
         ),
     ],
 )
@@ -86,7 +86,7 @@ def test_format_linter_error(error_linter, error_mate):
 def test_format_functions_one_line(func):
     code = inspect.getsource(func)
     assert (
-            isinstance(ast.parse(code).body[0].body[0], ast.Return) is True
+        isinstance(ast.parse(code).body[0].body[0], ast.Return) is True
     ), f"Function '{func.__name__}' should contain only return statement"
 
 
@@ -160,7 +160,7 @@ def test_format_single_linter_file(file_path, errors, result):
                         "column_number": 80,
                         "text": "line too long (99 > 79 characters)",
                         "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                         "store and decorate numbers: {', '.join(items)}!\"",
+                        "store and decorate numbers: {', '.join(items)}!\"",
                     },
                     {
                         "code": "W292",
@@ -169,7 +169,7 @@ def test_format_single_linter_file(file_path, errors, result):
                         "column_number": 100,
                         "text": "no newline at end of file",
                         "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                         "store and decorate numbers: {', '.join(items)}!\"",
+                        "store and decorate numbers: {', '.join(items)}!\"",
                     },
                 ],
                 "./source_code_1.py": [
@@ -180,7 +180,7 @@ def test_format_single_linter_file(file_path, errors, result):
                         "column_number": 74,
                         "text": "multiple statements on one line (semicolon)",
                         "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                                         "value in items.items()]; return func(new_items)\n",
+                        "value in items.items()]; return func(new_items)\n",
                     },
                     {
                         "code": "E501",
@@ -189,7 +189,7 @@ def test_format_single_linter_file(file_path, errors, result):
                         "column_number": 80,
                         "text": "line too long (97 > 79 characters)",
                         "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                                         "value in items.items()]; return func(new_items)\n",
+                        "value in items.items()]; return func(new_items)\n",
                     },
                     {
                         "code": "E302",
@@ -233,7 +233,7 @@ def test_format_single_linter_file(file_path, errors, result):
                         "column_number": 80,
                         "text": "line too long (84 > 79 characters)",
                         "physical_line": '            "decorate numbers: 1 -> 2, 2 -> 4, 6 -> 12, -111 -> -222, -50 -> '
-                                         '-100!",\n',
+                        '-100!",\n',
                     },
                     {
                         "code": "W292",
@@ -246,96 +246,96 @@ def test_format_single_linter_file(file_path, errors, result):
                 ],
             },
             [
-                    {"errors": [], "path": "./test_source_code_2.py", "status": "passed"},
-                    {
-                        "errors": [
-                            {
-                                "line": 18,
-                                "column": 80,
-                                "message": "line too long (99 > 79 characters)",
-                                "name": "E501",
-                                "source": "flake8",
-                            },
-                            {
-                                "line": 18,
-                                "column": 100,
-                                "message": "no newline at end of file",
-                                "name": "W292",
-                                "source": "flake8",
-                            },
-                        ],
-                        "path": "./source_code_2.py",
-                        "status": "failed",
-                    },
-                    {
-                        "errors": [
-                            {
-                                "line": 3,
-                                "column": 74,
-                                "message": "multiple statements on one line (semicolon)",
-                                "name": "E702",
-                                "source": "flake8",
-                            },
-                            {
-                                "line": 3,
-                                "column": 80,
-                                "message": "line too long (97 > 79 characters)",
-                                "name": "E501",
-                                "source": "flake8",
-                            },
-                            {
-                                "line": 15,
-                                "column": 1,
-                                "message": "expected 2 blank lines, found 1",
-                                "name": "E302",
-                                "source": "flake8",
-                            },
-                            {
-                                "line": 27,
-                                "column": 1,
-                                "message": "too many blank lines (6)",
-                                "name": "E303",
-                                "source": "flake8",
-                            },
-                            {
-                                "line": 31,
-                                "column": 80,
-                                "message": "line too long (99 > 79 characters)",
-                                "name": "E501",
-                                "source": "flake8",
-                            },
-                        ],
-                        "path": "./source_code_1.py",
-                        "status": "failed",
-                    },
-                    {
-                        "errors": [
-                            {
-                                "line": 4,
-                                "column": 1,
-                                "message": "expected 2 blank lines, found 1",
-                                "name": "E302",
-                                "source": "flake8",
-                            },
-                            {
-                                "line": 32,
-                                "column": 80,
-                                "message": "line too long (84 > 79 characters)",
-                                "name": "E501",
-                                "source": "flake8",
-                            },
-                            {
-                                "line": 112,
-                                "column": 6,
-                                "message": "no newline at end of file",
-                                "name": "W292",
-                                "source": "flake8",
-                            },
-                        ],
-                        "path": "./test_source_code_1.py",
-                        "status": "failed",
-                    },
-                ],
+                {"errors": [], "path": "./test_source_code_2.py", "status": "passed"},
+                {
+                    "errors": [
+                        {
+                            "line": 18,
+                            "column": 80,
+                            "message": "line too long (99 > 79 characters)",
+                            "name": "E501",
+                            "source": "flake8",
+                        },
+                        {
+                            "line": 18,
+                            "column": 100,
+                            "message": "no newline at end of file",
+                            "name": "W292",
+                            "source": "flake8",
+                        },
+                    ],
+                    "path": "./source_code_2.py",
+                    "status": "failed",
+                },
+                {
+                    "errors": [
+                        {
+                            "line": 3,
+                            "column": 74,
+                            "message": "multiple statements on one line (semicolon)",
+                            "name": "E702",
+                            "source": "flake8",
+                        },
+                        {
+                            "line": 3,
+                            "column": 80,
+                            "message": "line too long (97 > 79 characters)",
+                            "name": "E501",
+                            "source": "flake8",
+                        },
+                        {
+                            "line": 15,
+                            "column": 1,
+                            "message": "expected 2 blank lines, found 1",
+                            "name": "E302",
+                            "source": "flake8",
+                        },
+                        {
+                            "line": 27,
+                            "column": 1,
+                            "message": "too many blank lines (6)",
+                            "name": "E303",
+                            "source": "flake8",
+                        },
+                        {
+                            "line": 31,
+                            "column": 80,
+                            "message": "line too long (99 > 79 characters)",
+                            "name": "E501",
+                            "source": "flake8",
+                        },
+                    ],
+                    "path": "./source_code_1.py",
+                    "status": "failed",
+                },
+                {
+                    "errors": [
+                        {
+                            "line": 4,
+                            "column": 1,
+                            "message": "expected 2 blank lines, found 1",
+                            "name": "E302",
+                            "source": "flake8",
+                        },
+                        {
+                            "line": 32,
+                            "column": 80,
+                            "message": "line too long (84 > 79 characters)",
+                            "name": "E501",
+                            "source": "flake8",
+                        },
+                        {
+                            "line": 112,
+                            "column": 6,
+                            "message": "no newline at end of file",
+                            "name": "W292",
+                            "source": "flake8",
+                        },
+                    ],
+                    "path": "./test_source_code_1.py",
+                    "status": "failed",
+                },
+            ],
         )
     ],
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,14 +1,8 @@
 import pytest
-import re
 import ast
 import inspect
 
-from app.main import (
-    format_linter_error,
-    format_single_linter_file,
-    format_linter_report,
-)
-
+from app import main
 
 @pytest.mark.parametrize(
     "error_linter,error_mate",
@@ -69,7 +63,7 @@ from app.main import (
     ],
 )
 def test_format_linter_error(error_linter, error_mate):
-    assert format_linter_error(error_linter) == error_mate, (
+    assert main.format_linter_error(error_linter) == error_mate, (
         f"Function 'format_linter_error' should return {error_mate}, "
         f"when 'error' equals to {error_linter}"
     )
@@ -78,9 +72,9 @@ def test_format_linter_error(error_linter, error_mate):
 @pytest.mark.parametrize(
     "func",
     [
-        format_linter_error,
-        format_single_linter_file,
-        format_linter_report,
+        main.format_linter_error,
+        main.format_single_linter_file,
+        main.format_linter_report,
     ],
 )
 def test_format_functions_one_line(func):
@@ -139,7 +133,7 @@ def test_format_functions_one_line(func):
     ],
 )
 def test_format_single_linter_file(file_path, errors, result):
-    assert format_single_linter_file(file_path, errors) == result, (
+    assert main.format_single_linter_file(file_path, errors) == result, (
         f"Function 'format_single_linter_file' should return {result}, "
         f"when 'file_path' equals to {file_path}, "
         f"and 'errors' equals to {errors}"
@@ -340,28 +334,19 @@ def test_format_single_linter_file(file_path, errors, result):
     ],
 )
 def test_format_linter_report(errors_linter, errors_mate):
-    assert format_linter_report(errors_linter) == errors_mate, (
+    assert main.format_linter_report(errors_linter) == errors_mate, (
         f"Function 'format_linter_report' should return {errors_mate} "
         f"when 'errors' equals to {errors_linter}"
     )
 
 
-def test_removed_comment():
-    import app
-    with open(app.main.__file__, "r") as f:
-        file_content = f.read()
-        comment = re.compile("# write your code here")
-        assert not comment.search(
-            file_content
-        ), "You have to remove the unnecessary comment '# write your code here'"
+def test_comment_deleted():
+    lines = inspect.getsource(main)
+    assert "# write your code here" not in lines, ("Remove the unnecessary"
+        " comment '# write your code here'")
 
 
 def test_double_quotes_instead_of_single():
-    import app
-    with open(app.main.__file__, "r") as f:
-        file_content = f.read()
-        comment = re.compile("\'")
-        assert not comment.search(
-            file_content
-        ), "You have to use a double quotes \"\" instead of single \'\'"
-
+    lines = inspect.getsource(main)
+    assert "\'" not in lines, ("You have to use a double quotes \"\" instead"
+                               " of single \'\'")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -214,7 +214,7 @@ def test_format_single_linter_file(file_path, errors, result):
                         "column_number": 80,
                         "text": "line too long (99 > 79 characters)",
                         "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                         "store and decorate numbers: {', '.join(items)}!\"\n",
+                        "store and decorate numbers: {', '.join(items)}!\"\n",
                     },
                 ],
                 "./test_source_code_1.py": [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,46 +95,46 @@ def test_format_functions_one_line(func):
     [
         (
             "./source_code_2.py",
-                [
+            [
+                {
+                    "code": "E501",
+                    "filename": "./source_code_2.py",
+                    "line_number": 18,
+                    "column_number": 80,
+                    "text": "line too long (99 > 79 characters)",
+                    "physical_line": '    return f"I like to filter, rounding, doubling, '
+                    "store and decorate numbers: {', '.join(items)}!\"",
+                },
+                {
+                    "code": "W292",
+                    "filename": "./source_code_2.py",
+                    "line_number": 18,
+                    "column_number": 100,
+                    "text": "no newline at end of file",
+                    "physical_line": '    return f"I like to filter, rounding, doubling, '
+                    "store and decorate numbers: {', '.join(items)}!\"",
+                },
+            ],
+            {
+                "errors": [
                     {
-                        "code": "E501",
-                        "filename": "./source_code_2.py",
-                        "line_number": 18,
-                        "column_number": 80,
-                        "text": "line too long (99 > 79 characters)",
-                        "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                         "store and decorate numbers: {', '.join(items)}!\"",
+                        "line": 18,
+                        "column": 80,
+                        "message": "line too long (99 > 79 characters)",
+                        "name": "E501",
+                        "source": "flake8",
                     },
                     {
-                        "code": "W292",
-                        "filename": "./source_code_2.py",
-                        "line_number": 18,
-                        "column_number": 100,
-                        "text": "no newline at end of file",
-                        "physical_line": '    return f"I like to filter, rounding, doubling, '
-                                         "store and decorate numbers: {', '.join(items)}!\"",
+                        "line": 18,
+                        "column": 100,
+                        "message": "no newline at end of file",
+                        "name": "W292",
+                        "source": "flake8",
                     },
                 ],
-                {
-                    "errors": [
-                        {
-                            "line": 18,
-                            "column": 80,
-                            "message": "line too long (99 > 79 characters)",
-                            "name": "E501",
-                            "source": "flake8",
-                        },
-                        {
-                            "line": 18,
-                            "column": 100,
-                            "message": "no newline at end of file",
-                            "name": "W292",
-                            "source": "flake8",
-                        },
-                    ],
-                    "path": "./source_code_2.py",
-                    "status": "failed",
-                },
+                "path": "./source_code_2.py",
+                "status": "failed",
+            },
         )
     ],
 )
@@ -348,11 +348,13 @@ def test_format_linter_report(errors_linter, errors_mate):
 
 def test_comment_deleted():
     lines = inspect.getsource(main)
-    assert "# write your code here" not in lines, ("Remove the unnecessary"
-                                                   " comment '# write your code here'")
+    assert "# write your code here" not in lines, (
+        "Remove the unnecessary" " comment '# write your code here'"
+    )
 
 
 def test_double_quotes_instead_of_single():
     lines = inspect.getsource(main)
-    assert "\'" not in lines, ("You have to use a double quotes \"\" instead"
-                               " of single \'\'")
+    assert "'" not in lines, (
+        'You have to use a double quotes "" instead' " of single ''"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,67 +3,73 @@ import ast
 import inspect
 
 from app import main
+from app.main import (
+    format_linter_error,
+    format_single_linter_file,
+    format_linter_report,
+)
+
 
 @pytest.mark.parametrize(
     "error_linter,error_mate",
     [
         (
-            {
-                "code": "E501",
-                "filename": "./source_code_2.py",
-                "line_number": 18,
-                "column_number": 80,
-                "text": "line too long (99 > 79 characters)",
-                "physical_line": '    return f"I like to filter, rounding, doubling, '
-                "store and decorate numbers: {', '.join(items)}!\"",
-            },
-            {
-                "line": 18,
-                "column": 80,
-                "message": "line too long (99 > 79 characters)",
-                "name": "E501",
-                "source": "flake8",
-            },
+                {
+                    "code": "E501",
+                    "filename": "./source_code_2.py",
+                    "line_number": 18,
+                    "column_number": 80,
+                    "text": "line too long (99 > 79 characters)",
+                    "physical_line": '    return f"I like to filter, rounding, doubling, '
+                                     "store and decorate numbers: {', '.join(items)}!\"",
+                },
+                {
+                    "line": 18,
+                    "column": 80,
+                    "message": "line too long (99 > 79 characters)",
+                    "name": "E501",
+                    "source": "flake8",
+                },
         ),
         (
-            {
-                "code": "E702",
-                "filename": "./source_code_1.py",
-                "line_number": 3,
-                "column_number": 74,
-                "text": "multiple statements on one line (semicolon)",
-                "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                "value in items.items()]; return func(new_items)\n",
-            },
-            {
-                "line": 3,
-                "column": 74,
-                "message": "multiple statements on one line (semicolon)",
-                "name": "E702",
-                "source": "flake8",
-            },
+                {
+                    "code": "E702",
+                    "filename": "./source_code_1.py",
+                    "line_number": 3,
+                    "column_number": 74,
+                    "text": "multiple statements on one line (semicolon)",
+                    "physical_line": '        new_items = [f"{key} -> {value}" for key, '
+                                     "value in items.items()]; return func(new_items)\n",
+                },
+                {
+                    "line": 3,
+                    "column": 74,
+                    "message": "multiple statements on one line (semicolon)",
+                    "name": "E702",
+                    "source": "flake8",
+                },
         ),
         (
-            {
-                "code": "E302",
-                "filename": "./source_code_1.py",
-                "line_number": 15,
-                "column_number": 1,
-                "text": "expected 2 blank lines, found 1",
-                "physical_line": "def number_filter(func):\n",
-            },
-            {
-                "line": 15,
-                "column": 1,
-                "message": "expected 2 blank lines, found 1",
-                "name": "E302",
-                "source": "flake8",
-            },
+                {
+                    "code": "E302",
+                    "filename": "./source_code_1.py",
+                    "line_number": 15,
+                    "column_number": 1,
+                    "text": "expected 2 blank lines, found 1",
+                    "physical_line": "def number_filter(func):\n",
+                },
+                {
+                    "line": 15,
+                    "column": 1,
+                    "message": "expected 2 blank lines, found 1",
+                    "name": "E302",
+                    "source": "flake8",
+                },
         ),
     ],
 )
 def test_format_linter_error(error_linter, error_mate):
-    assert main.format_linter_error(error_linter) == error_mate, (
+    assert format_linter_error(error_linter) == error_mate, (
         f"Function 'format_linter_error' should return {error_mate}, "
         f"when 'error' equals to {error_linter}"
     )
@@ -72,15 +78,15 @@ def test_format_linter_error(error_linter, error_mate):
 @pytest.mark.parametrize(
     "func",
     [
-        main.format_linter_error,
-        main.format_single_linter_file,
-        main.format_linter_report,
+        format_linter_error,
+        format_single_linter_file,
+        format_linter_report,
     ],
 )
 def test_format_functions_one_line(func):
     code = inspect.getsource(func)
     assert (
-        isinstance(ast.parse(code).body[0].body[0], ast.Return) is True
+            isinstance(ast.parse(code).body[0].body[0], ast.Return) is True
     ), f"Function '{func.__name__}' should contain only return statement"
 
 
@@ -88,65 +94,8 @@ def test_format_functions_one_line(func):
     "file_path,errors,result",
     [
         (
-            "./source_code_2.py",
-            [
-                {
-                    "code": "E501",
-                    "filename": "./source_code_2.py",
-                    "line_number": 18,
-                    "column_number": 80,
-                    "text": "line too long (99 > 79 characters)",
-                    "physical_line": '    return f"I like to filter, rounding, doubling, '
-                    "store and decorate numbers: {', '.join(items)}!\"",
-                },
-                {
-                    "code": "W292",
-                    "filename": "./source_code_2.py",
-                    "line_number": 18,
-                    "column_number": 100,
-                    "text": "no newline at end of file",
-                    "physical_line": '    return f"I like to filter, rounding, doubling, '
-                    "store and decorate numbers: {', '.join(items)}!\"",
-                },
-            ],
-            {
-                "errors": [
-                    {
-                        "line": 18,
-                        "column": 80,
-                        "message": "line too long (99 > 79 characters)",
-                        "name": "E501",
-                        "source": "flake8",
-                    },
-                    {
-                        "line": 18,
-                        "column": 100,
-                        "message": "no newline at end of file",
-                        "name": "W292",
-                        "source": "flake8",
-                    },
-                ],
-                "path": "./source_code_2.py",
-                "status": "failed",
-            },
-        )
-    ],
-)
-def test_format_single_linter_file(file_path, errors, result):
-    assert main.format_single_linter_file(file_path, errors) == result, (
-        f"Function 'format_single_linter_file' should return {result}, "
-        f"when 'file_path' equals to {file_path}, "
-        f"and 'errors' equals to {errors}"
-    )
-
-
-@pytest.mark.parametrize(
-    "errors_linter,errors_mate",
-    [
-        (
-            {
-                "./test_source_code_2.py": [],
-                "./source_code_2.py": [
+                "./source_code_2.py",
+                [
                     {
                         "code": "E501",
                         "filename": "./source_code_2.py",
@@ -154,7 +103,7 @@ def test_format_single_linter_file(file_path, errors, result):
                         "column_number": 80,
                         "text": "line too long (99 > 79 characters)",
                         "physical_line": '    return f"I like to filter, rounding, doubling, '
-                        "store and decorate numbers: {', '.join(items)}!\"",
+                                         "store and decorate numbers: {', '.join(items)}!\"",
                     },
                     {
                         "code": "W292",
@@ -163,84 +112,9 @@ def test_format_single_linter_file(file_path, errors, result):
                         "column_number": 100,
                         "text": "no newline at end of file",
                         "physical_line": '    return f"I like to filter, rounding, doubling, '
-                        "store and decorate numbers: {', '.join(items)}!\"",
+                                         "store and decorate numbers: {', '.join(items)}!\"",
                     },
                 ],
-                "./source_code_1.py": [
-                    {
-                        "code": "E702",
-                        "filename": "./source_code_1.py",
-                        "line_number": 3,
-                        "column_number": 74,
-                        "text": "multiple statements on one line (semicolon)",
-                        "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                        "value in items.items()]; return func(new_items)\n",
-                    },
-                    {
-                        "code": "E501",
-                        "filename": "./source_code_1.py",
-                        "line_number": 3,
-                        "column_number": 80,
-                        "text": "line too long (97 > 79 characters)",
-                        "physical_line": '        new_items = [f"{key} -> {value}" for key, '
-                        "value in items.items()]; return func(new_items)\n",
-                    },
-                    {
-                        "code": "E302",
-                        "filename": "./source_code_1.py",
-                        "line_number": 15,
-                        "column_number": 1,
-                        "text": "expected 2 blank lines, found 1",
-                        "physical_line": "def number_filter(func):\n",
-                    },
-                    {
-                        "code": "E303",
-                        "filename": "./source_code_1.py",
-                        "line_number": 27,
-                        "column_number": 1,
-                        "text": "too many blank lines (6)",
-                        "physical_line": "@number_filter\n",
-                    },
-                    {
-                        "code": "E501",
-                        "filename": "./source_code_1.py",
-                        "line_number": 31,
-                        "column_number": 80,
-                        "text": "line too long (99 > 79 characters)",
-                        "physical_line": '    return f"I like to filter, rounding, doubling, '
-                        "store and decorate numbers: {', '.join(items)}!\"\n",
-                    },
-                ],
-                "./test_source_code_1.py": [
-                    {
-                        "code": "E302",
-                        "filename": "./test_source_code_1.py",
-                        "line_number": 4,
-                        "column_number": 1,
-                        "text": "expected 2 blank lines, found 1",
-                        "physical_line": "@pytest.mark.parametrize(\n",
-                    },
-                    {
-                        "code": "E501",
-                        "filename": "./test_source_code_1.py",
-                        "line_number": 32,
-                        "column_number": 80,
-                        "text": "line too long (84 > 79 characters)",
-                        "physical_line": '            "decorate numbers: 1 -> 2, 2 -> 4, 6 -> 12, -111 -> -222, -50 -> '
-                        '-100!",\n',
-                    },
-                    {
-                        "code": "W292",
-                        "filename": "./test_source_code_1.py",
-                        "line_number": 112,
-                        "column_number": 6,
-                        "text": "no newline at end of file",
-                        "physical_line": "    )",
-                    },
-                ],
-            },
-            [
-                {"errors": [], "path": "./test_source_code_2.py", "status": "passed"},
                 {
                     "errors": [
                         {
@@ -261,80 +135,212 @@ def test_format_single_linter_file(file_path, errors, result):
                     "path": "./source_code_2.py",
                     "status": "failed",
                 },
+        )
+    ],
+)
+def test_format_single_linter_file(file_path, errors, result):
+    assert format_single_linter_file(file_path, errors) == result, (
+        f"Function 'format_single_linter_file' should return {result}, "
+        f"when 'file_path' equals to {file_path}, "
+        f"and 'errors' equals to {errors}"
+    )
+
+
+@pytest.mark.parametrize(
+    "errors_linter,errors_mate",
+    [
+        (
                 {
-                    "errors": [
+                    "./test_source_code_2.py": [],
+                    "./source_code_2.py": [
                         {
-                            "line": 3,
-                            "column": 74,
-                            "message": "multiple statements on one line (semicolon)",
-                            "name": "E702",
-                            "source": "flake8",
+                            "code": "E501",
+                            "filename": "./source_code_2.py",
+                            "line_number": 18,
+                            "column_number": 80,
+                            "text": "line too long (99 > 79 characters)",
+                            "physical_line": '    return f"I like to filter, rounding, doubling, '
+                                             "store and decorate numbers: {', '.join(items)}!\"",
                         },
                         {
-                            "line": 3,
-                            "column": 80,
-                            "message": "line too long (97 > 79 characters)",
-                            "name": "E501",
-                            "source": "flake8",
-                        },
-                        {
-                            "line": 15,
-                            "column": 1,
-                            "message": "expected 2 blank lines, found 1",
-                            "name": "E302",
-                            "source": "flake8",
-                        },
-                        {
-                            "line": 27,
-                            "column": 1,
-                            "message": "too many blank lines (6)",
-                            "name": "E303",
-                            "source": "flake8",
-                        },
-                        {
-                            "line": 31,
-                            "column": 80,
-                            "message": "line too long (99 > 79 characters)",
-                            "name": "E501",
-                            "source": "flake8",
+                            "code": "W292",
+                            "filename": "./source_code_2.py",
+                            "line_number": 18,
+                            "column_number": 100,
+                            "text": "no newline at end of file",
+                            "physical_line": '    return f"I like to filter, rounding, doubling, '
+                                             "store and decorate numbers: {', '.join(items)}!\"",
                         },
                     ],
-                    "path": "./source_code_1.py",
-                    "status": "failed",
-                },
-                {
-                    "errors": [
+                    "./source_code_1.py": [
                         {
-                            "line": 4,
-                            "column": 1,
-                            "message": "expected 2 blank lines, found 1",
-                            "name": "E302",
-                            "source": "flake8",
+                            "code": "E702",
+                            "filename": "./source_code_1.py",
+                            "line_number": 3,
+                            "column_number": 74,
+                            "text": "multiple statements on one line (semicolon)",
+                            "physical_line": '        new_items = [f"{key} -> {value}" for key, '
+                                             "value in items.items()]; return func(new_items)\n",
                         },
                         {
-                            "line": 32,
-                            "column": 80,
-                            "message": "line too long (84 > 79 characters)",
-                            "name": "E501",
-                            "source": "flake8",
+                            "code": "E501",
+                            "filename": "./source_code_1.py",
+                            "line_number": 3,
+                            "column_number": 80,
+                            "text": "line too long (97 > 79 characters)",
+                            "physical_line": '        new_items = [f"{key} -> {value}" for key, '
+                                             "value in items.items()]; return func(new_items)\n",
                         },
                         {
-                            "line": 112,
-                            "column": 6,
-                            "message": "no newline at end of file",
-                            "name": "W292",
-                            "source": "flake8",
+                            "code": "E302",
+                            "filename": "./source_code_1.py",
+                            "line_number": 15,
+                            "column_number": 1,
+                            "text": "expected 2 blank lines, found 1",
+                            "physical_line": "def number_filter(func):\n",
+                        },
+                        {
+                            "code": "E303",
+                            "filename": "./source_code_1.py",
+                            "line_number": 27,
+                            "column_number": 1,
+                            "text": "too many blank lines (6)",
+                            "physical_line": "@number_filter\n",
+                        },
+                        {
+                            "code": "E501",
+                            "filename": "./source_code_1.py",
+                            "line_number": 31,
+                            "column_number": 80,
+                            "text": "line too long (99 > 79 characters)",
+                            "physical_line": '    return f"I like to filter, rounding, doubling, '
+                                             "store and decorate numbers: {', '.join(items)}!\"\n",
                         },
                     ],
-                    "path": "./test_source_code_1.py",
-                    "status": "failed",
+                    "./test_source_code_1.py": [
+                        {
+                            "code": "E302",
+                            "filename": "./test_source_code_1.py",
+                            "line_number": 4,
+                            "column_number": 1,
+                            "text": "expected 2 blank lines, found 1",
+                            "physical_line": "@pytest.mark.parametrize(\n",
+                        },
+                        {
+                            "code": "E501",
+                            "filename": "./test_source_code_1.py",
+                            "line_number": 32,
+                            "column_number": 80,
+                            "text": "line too long (84 > 79 characters)",
+                            "physical_line": '            "decorate numbers: 1 -> 2, 2 -> 4, 6 -> 12, -111 -> -222, -50 -> '
+                                             '-100!",\n',
+                        },
+                        {
+                            "code": "W292",
+                            "filename": "./test_source_code_1.py",
+                            "line_number": 112,
+                            "column_number": 6,
+                            "text": "no newline at end of file",
+                            "physical_line": "    )",
+                        },
+                    ],
                 },
-            ],
+                [
+                    {"errors": [], "path": "./test_source_code_2.py", "status": "passed"},
+                    {
+                        "errors": [
+                            {
+                                "line": 18,
+                                "column": 80,
+                                "message": "line too long (99 > 79 characters)",
+                                "name": "E501",
+                                "source": "flake8",
+                            },
+                            {
+                                "line": 18,
+                                "column": 100,
+                                "message": "no newline at end of file",
+                                "name": "W292",
+                                "source": "flake8",
+                            },
+                        ],
+                        "path": "./source_code_2.py",
+                        "status": "failed",
+                    },
+                    {
+                        "errors": [
+                            {
+                                "line": 3,
+                                "column": 74,
+                                "message": "multiple statements on one line (semicolon)",
+                                "name": "E702",
+                                "source": "flake8",
+                            },
+                            {
+                                "line": 3,
+                                "column": 80,
+                                "message": "line too long (97 > 79 characters)",
+                                "name": "E501",
+                                "source": "flake8",
+                            },
+                            {
+                                "line": 15,
+                                "column": 1,
+                                "message": "expected 2 blank lines, found 1",
+                                "name": "E302",
+                                "source": "flake8",
+                            },
+                            {
+                                "line": 27,
+                                "column": 1,
+                                "message": "too many blank lines (6)",
+                                "name": "E303",
+                                "source": "flake8",
+                            },
+                            {
+                                "line": 31,
+                                "column": 80,
+                                "message": "line too long (99 > 79 characters)",
+                                "name": "E501",
+                                "source": "flake8",
+                            },
+                        ],
+                        "path": "./source_code_1.py",
+                        "status": "failed",
+                    },
+                    {
+                        "errors": [
+                            {
+                                "line": 4,
+                                "column": 1,
+                                "message": "expected 2 blank lines, found 1",
+                                "name": "E302",
+                                "source": "flake8",
+                            },
+                            {
+                                "line": 32,
+                                "column": 80,
+                                "message": "line too long (84 > 79 characters)",
+                                "name": "E501",
+                                "source": "flake8",
+                            },
+                            {
+                                "line": 112,
+                                "column": 6,
+                                "message": "no newline at end of file",
+                                "name": "W292",
+                                "source": "flake8",
+                            },
+                        ],
+                        "path": "./test_source_code_1.py",
+                        "status": "failed",
+                    },
+                ],
         )
     ],
 )
 def test_format_linter_report(errors_linter, errors_mate):
-    assert main.format_linter_report(errors_linter) == errors_mate, (
+    assert format_linter_report(errors_linter) == errors_mate, (
         f"Function 'format_linter_report' should return {errors_mate} "
         f"when 'errors' equals to {errors_linter}"
     )
@@ -343,7 +349,7 @@ def test_format_linter_report(errors_linter, errors_mate):
 def test_comment_deleted():
     lines = inspect.getsource(main)
     assert "# write your code here" not in lines, ("Remove the unnecessary"
-        " comment '# write your code here'")
+                                                   " comment '# write your code here'")
 
 
 def test_double_quotes_instead_of_single():


### PR DESCRIPTION
## Implementing the Missing Functions

### `format_linter_error`
This function will take a linter error object and format it into a human-readable string.

```python
def format_linter_error(error):
  """Formats a linter error object into a human-readable string.

  Args:
    error: A linter error object.

  Returns:
    A string representing the formatted error message.
  """

  # Extract relevant information from the error object
  line_number = error.get("line_number", 0)
  column_number = error.get("column_number", 0)
  message = error.get("message", "")

  # Construct the formatted error message
  formatted_message = f"Error on line {line_number}, column {column_number}: {message}"

  return formatted_message
```

### `format_single_linter_file`
This function will take a list of linter errors for a single file and format them into a human-readable string.

```python
def format_single_linter_file(file_path, errors):
  """Formats a list of linter errors for a single file into a human-readable string.

  Args:
    file_path: The path to the file.
    errors: A list of linter error objects.

  Returns:
    A string representing the formatted errors for the file.
  """

  formatted_errors = [format_linter_error(error) for error in errors]
  formatted_output = f"Linter errors for {file_path}:\n" + "\n".join(formatted_errors)

  return formatted_output
```

### `format_linter_report`
This function will take a list of linter errors for multiple files and format them into a human-readable string.

```python
def format_linter_report(linter_results):
  """Formats a list of linter errors for multiple files into a human-readable string.

  Args:
    linter_results: A list of tuples, where each tuple contains a file path and a list of linter errors for that file.

  Returns:
    A string representing the formatted linter report.
  """

  formatted_reports = [format_single_linter_file(file_path, errors) for file_path, errors in linter_results]
  formatted_output = "\n".join(formatted_reports)

  return formatted_output
```

**Explanation:**

These functions provide a basic structure for formatting linter errors. You can customize them further based on your specific needs and the structure of your linter error objects. For example, you might want to add more details to the formatted error messages or include statistics about the number of errors found.

**Remember to replace the placeholder `linter_error` object with the actual structure of the linter errors you're working with.**

