### PR TITLE
format_linter_error is used in the format_single_linter_file function…

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,11 @@
 def format_linter_error(error: dict) -> dict:
-        return {
-            "line": error["line_number"],
-            "column": error["column_number"],
-            "message": error["text"],
-            "name": error["code"],
-            "source": "flake8",
-        }
+    return {
+        "line": error["line_number"],
+        "column": error["column_number"],
+        "message": error["text"],
+        "name": error["code"],
+        "source": "flake8",
+    }
 
 
 def format_single_linter_file(file_path: str, errors: list) -> dict:

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,23 @@
 def format_linter_error(error: dict) -> dict:
-    # write your code here
-    pass
+        return {
+            "line": error["line_number"],
+            "column": error["column_number"],
+            "message": error["text"],
+            "name": error["code"],
+            "source": "flake8",
+        }
 
 
 def format_single_linter_file(file_path: str, errors: list) -> dict:
-    # write your code here
-    pass
+    return {
+        "errors": [format_linter_error(error) for error in errors],
+        "path": file_path,
+        "status": "failed" if errors else "passed",
+    }
 
 
 def format_linter_report(linter_report: dict) -> list:
-    # write your code here
-    pass
+    return [
+        format_single_linter_file(file_path, file_errors)
+        for file_path, file_errors in linter_report.items()
+    ]


### PR DESCRIPTION
… for each error.

format_single_linter_file is used in the format_linter_report function for each file. So all three functions are related, and each does its part of the work to get the final report format.