### PR TITLE
Add linter report formatting functions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,24 @@
 def format_linter_error(error: dict) -> dict:
-    # write your code here
-    pass
+    return {
+        "line": error["line_number"],
+        "column": error["column_number"],
+        "message": error["text"],
+        "name": error["code"],
+        "source": "flake8"
+    }
 
 
 def format_single_linter_file(file_path: str, errors: list) -> dict:
-    # write your code here
-    pass
+    return {
+        "errors": [format_linter_error(error) for error in errors],
+        "path": file_path,
+        "status": "failed" if errors else "passed"
+    }
 
 
 def format_linter_report(linter_report: dict) -> list:
-    # write your code here
-    pass
+    return [
+        format_single_linter_file(file_path, errors)
+        for file_path, errors in linter_report.items()
+    ]
+

--- a/app/main.py
+++ b/app/main.py
@@ -21,4 +21,3 @@ def format_linter_report(linter_report: dict) -> list:
         format_single_linter_file(file_path, errors)
         for file_path, errors in linter_report.items()
     ]
-


### PR DESCRIPTION
- format_linter_error: formats a single flake8 error
- format_single_linter_file: formats all errors for a single file, adds path and status
- format_linter_report: formats the whole linter report for all files
- All functions now pass the pytest tests